### PR TITLE
Proof of Concept implementation of new DoubleSummaryStatistics API

### DIFF
--- a/sample-stats/pom.xml
+++ b/sample-stats/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.poc</groupId>
+    <artifactId>sample-stats</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <jvm.target>8</jvm.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>${jvm.target}</maven.compiler.release>
+    </properties>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/sample-stats/src/main/java/org/poc/sample/stats/DoubleSummaryStatistics.java
+++ b/sample-stats/src/main/java/org/poc/sample/stats/DoubleSummaryStatistics.java
@@ -1,0 +1,161 @@
+package org.poc.sample.stats;
+
+import org.poc.sample.stats.config.SummaryStatisticsConfig;
+import org.poc.sample.stats.internal.StatisticImplProvider;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+public class DoubleSummaryStatistics {
+
+    private final SummaryStatisticsConfig config;
+
+    private long n;
+
+    // sum
+    UnivaritateStatistic sumImpl;
+
+    // mean
+    UnivaritateStatistic meanImpl;
+
+    // variance
+    UnivaritateStatistic varianceImpl;
+
+    private DoubleSummaryStatistics(final SummaryStatisticsConfig config) {
+        this.config = config;
+        StatisticImplProvider implProvider = StatisticImplProvider.initConfig(config);
+
+        n = 0;
+        sumImpl = implProvider.getSumImpl();
+        meanImpl = implProvider.getMeanImpl();
+        varianceImpl = implProvider.getVarianceImpl();
+    }
+
+    public static DoubleSummaryStatistics withCustom(SummaryStatisticsConfig customConfig) {
+        return new DoubleSummaryStatistics(customConfig);
+    }
+
+    public static DoubleSummaryStatistics withDefault() {
+        return new DoubleSummaryStatistics(SummaryStatisticsConfig.DEFAULT_CONFIG);
+    }
+
+    public static Collector<Double, DoubleSummaryStatistics, StatisticalSummary> summarize() {
+        return summarize(DoubleSummaryStatistics::withDefault);
+    }
+
+    public static Collector<Double, DoubleSummaryStatistics, StatisticalSummary> summarize(SummaryStatisticsConfig config) {
+        return summarize(() -> DoubleSummaryStatistics.withCustom(config));
+    }
+
+    public DoubleSummaryStatistics of(Collection<Double> values) {
+        values.forEach(this::addValue);
+        return this;
+    }
+
+    public StatisticalSummary toStatisticalSummary() {
+        return new Result(n, sumImpl.getAsDouble(), meanImpl.getAsDouble(), varianceImpl.getAsDouble());
+    }
+
+    public DoubleSummaryStatistics addValue(double d) {
+        n++;
+        sumImpl.accept(d);
+        meanImpl.accept(d);
+        varianceImpl.accept(d);
+
+        return this;
+    }
+
+    private static Collector<Double, DoubleSummaryStatistics, StatisticalSummary> summarize(Supplier<DoubleSummaryStatistics> supplier) {
+        return Collector.of(
+                supplier,
+                DoubleSummaryStatistics::addValue,
+                DoubleSummaryStatistics::merge,
+                DoubleSummaryStatistics::toStatisticalSummary,
+                Collector.Characteristics.UNORDERED);
+    }
+
+    private DoubleSummaryStatistics merge(DoubleSummaryStatistics other) {
+        // This is only called from the context of SummaryStatistic#summarize where *we control* the SummaryStatistic object creation logic
+        // So it is safe to assume that each of these merge functions are type safe since both the partial SummaryStatistics
+        // being merged here are created with the same config which means they use the same implementations to compute StatisticalSummary
+        // So the hashCode check below is redundant
+//        if (this.config.hashCode() != other.config.hashCode()) {
+//            throw new IllegalArgumentException("Cannot merge SummaryStatistic instances with different SummaryStatisticsConfig");
+//        }
+
+        sumImpl.merge(other.sumImpl);
+        meanImpl.merge(other.meanImpl);
+        varianceImpl.merge(other.varianceImpl);
+
+        return this;
+    }
+
+    static class Result implements StatisticalSummary {
+
+        private long n;
+
+        // running sum
+        private double sum;
+
+        // mean
+        private double mean;
+
+        // variance
+        private double variance;
+
+        private Result(final long n,
+                       final double sum,
+                       final double mean,
+                       final double variance) {
+            this.n = n;
+            this.sum = sum;
+            this.mean = mean;
+            this.variance = variance;
+        }
+
+        @Override
+        public double getMean() {
+            return mean;
+        }
+
+        @Override
+        public double getVariance() {
+            return variance;
+        }
+
+        @Override
+        public double getStandardDeviation() {
+            return 0;
+        }
+
+        @Override
+        public double getMax() {
+            return 0;
+        }
+
+        @Override
+        public double getMin() {
+            return 0;
+        }
+
+        @Override
+        public long getN() {
+            return n;
+        }
+
+        @Override
+        public double getSum() {
+            return sum;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("Sum = ").append(sum).append("\n");
+            sb.append("Mean = ").append(mean).append("\n");
+            return sb.toString();
+        }
+    }
+}

--- a/sample-stats/src/main/java/org/poc/sample/stats/StatisticalSummary.java
+++ b/sample-stats/src/main/java/org/poc/sample/stats/StatisticalSummary.java
@@ -1,0 +1,18 @@
+package org.poc.sample.stats;
+
+public interface StatisticalSummary {
+
+    double getMean();
+
+    double getVariance();
+
+    double getStandardDeviation();
+
+    double getMax();
+
+    double getMin();
+
+    long getN();
+
+    double getSum();
+}

--- a/sample-stats/src/main/java/org/poc/sample/stats/UnivaritateStatistic.java
+++ b/sample-stats/src/main/java/org/poc/sample/stats/UnivaritateStatistic.java
@@ -1,0 +1,9 @@
+package org.poc.sample.stats;
+
+import java.util.function.DoubleConsumer;
+import java.util.function.DoubleSupplier;
+
+public interface UnivaritateStatistic extends DoubleConsumer, DoubleSupplier {
+    long getN();
+    void merge(UnivaritateStatistic other);
+}

--- a/sample-stats/src/main/java/org/poc/sample/stats/config/MeanConfig.java
+++ b/sample-stats/src/main/java/org/poc/sample/stats/config/MeanConfig.java
@@ -1,0 +1,15 @@
+package org.poc.sample.stats.config;
+
+public enum MeanConfig {
+    Sum,
+    Rolling,
+    ;
+
+    public boolean isSum() {
+        return this == Sum;
+    }
+
+    public boolean isRolling() {
+        return this == Rolling;
+    }
+}

--- a/sample-stats/src/main/java/org/poc/sample/stats/config/Statistic.java
+++ b/sample-stats/src/main/java/org/poc/sample/stats/config/Statistic.java
@@ -1,0 +1,8 @@
+package org.poc.sample.stats.config;
+
+public enum Statistic {
+    Sum,
+    Mean,
+    Variance,
+    ;
+}

--- a/sample-stats/src/main/java/org/poc/sample/stats/config/SummaryStatisticsConfig.java
+++ b/sample-stats/src/main/java/org/poc/sample/stats/config/SummaryStatisticsConfig.java
@@ -1,0 +1,98 @@
+package org.poc.sample.stats.config;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Objects;
+
+public class SummaryStatisticsConfig {
+
+    private final MeanConfig meanConfig;
+    private final VarianceConfig varianceConfig;
+    private final EnumSet<Statistic> statisticsToCompute = EnumSet.noneOf(Statistic.class);
+
+    private final int hash;
+
+    static final MeanConfig DEFAULT_MEAN_CONFIG = MeanConfig.Sum;
+    static final VarianceConfig DEFAULT_VARIANCE_CONFIG = VarianceConfig.Sample;
+
+    public static final SummaryStatisticsConfig DEFAULT_CONFIG =
+            new SummaryStatisticsConfig(DEFAULT_MEAN_CONFIG, DEFAULT_VARIANCE_CONFIG, EnumSet.allOf(Statistic.class));
+
+    private SummaryStatisticsConfig(final MeanConfig meanConfig,
+                                    final VarianceConfig varianceConfig,
+                                    final EnumSet<Statistic> statisticsToCompute) {
+        this.meanConfig = meanConfig;
+        this.varianceConfig = varianceConfig;
+        this.statisticsToCompute.addAll(statisticsToCompute);
+        this.hash = Objects.hash(meanConfig, varianceConfig, statisticsToCompute);
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public MeanConfig getMeanConfig() {
+        return this.meanConfig;
+    }
+
+    public VarianceConfig getVarianceConfig() {
+        return this.varianceConfig;
+    }
+
+    public boolean shouldCompute(Statistic statistic) {
+        return this.statisticsToCompute.contains(statistic);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SummaryStatisticsConfig that = (SummaryStatisticsConfig) o;
+        return meanConfig == that.meanConfig && varianceConfig == that.varianceConfig && Objects.equals(statisticsToCompute, that.statisticsToCompute);
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
+    }
+
+    public static class Builder {
+        private MeanConfig meanConfig = DEFAULT_MEAN_CONFIG;
+        private VarianceConfig varianceConfig = DEFAULT_VARIANCE_CONFIG;
+        private EnumSet<Statistic> statisticsToCompute = EnumSet.allOf(Statistic.class);
+
+        private Builder() {
+            // assign default impl here
+        }
+
+        public Builder withMeanConfig(final MeanConfig config) {
+            this.meanConfig = meanConfig;
+            return this;
+        }
+
+        public Builder withVarianceConfig(final VarianceConfig varianceConfig) {
+            this.varianceConfig = varianceConfig;
+            return this;
+        }
+
+        // TODO: Just for now. Planning to overload this to take 1, 2, 3, 4, 5, 6 params ?
+        public Builder only(Statistic statisticToInclude, Statistic... statisticsToInclude) {
+            this.statisticsToCompute.clear();
+            this.statisticsToCompute.add(statisticToInclude);
+            Collections.addAll(this.statisticsToCompute, statisticsToInclude);
+            return this;
+        }
+
+        public Builder excluding(Statistic statisticToExclude, Statistic... statisticsToExclude) {
+            this.statisticsToCompute.clear();
+            EnumSet<Statistic> excludedStatistics = EnumSet.of(statisticToExclude);
+            Collections.addAll(excludedStatistics, statisticsToExclude);
+            this.statisticsToCompute = EnumSet.complementOf(excludedStatistics);
+            return this;
+        }
+
+        public SummaryStatisticsConfig build() {
+            return new SummaryStatisticsConfig(this.meanConfig, this.varianceConfig, this.statisticsToCompute);
+        }
+    }
+}

--- a/sample-stats/src/main/java/org/poc/sample/stats/config/VarianceConfig.java
+++ b/sample-stats/src/main/java/org/poc/sample/stats/config/VarianceConfig.java
@@ -1,0 +1,15 @@
+package org.poc.sample.stats.config;
+
+public enum VarianceConfig {
+    Population,
+    Sample,
+    ;
+
+    public boolean isSampleVariance() {
+        return this == Sample;
+    }
+
+    public boolean isPopulationVariance() {
+        return this == Population;
+    }
+}

--- a/sample-stats/src/main/java/org/poc/sample/stats/internal/DefaultUnivariateStatisticImpl.java
+++ b/sample-stats/src/main/java/org/poc/sample/stats/internal/DefaultUnivariateStatisticImpl.java
@@ -1,0 +1,30 @@
+package org.poc.sample.stats.internal;
+
+import org.poc.sample.stats.UnivaritateStatistic;
+
+class DefaultUnivariateStatisticImpl implements UnivaritateStatistic {
+
+    private static final DefaultUnivariateStatisticImpl INSTANCE = new DefaultUnivariateStatisticImpl();
+
+    private DefaultUnivariateStatisticImpl() {}
+
+    @Override
+    public long getN() {
+        return 0;
+    }
+
+    @Override
+    public void merge(UnivaritateStatistic other) {}
+
+    @Override
+    public void accept(double value) {}
+
+    @Override
+    public double getAsDouble() {
+        return Double.NaN;
+    }
+
+    public static DefaultUnivariateStatisticImpl getInstance() {
+        return INSTANCE;
+    }
+}

--- a/sample-stats/src/main/java/org/poc/sample/stats/internal/FirstMoment.java
+++ b/sample-stats/src/main/java/org/poc/sample/stats/internal/FirstMoment.java
@@ -1,0 +1,75 @@
+package org.poc.sample.stats.internal;
+
+import org.poc.sample.stats.UnivaritateStatistic;
+
+class FirstMoment implements UnivaritateStatistic {
+    private long n;
+    private double m1;
+    private double dev;
+    private double nDev;
+
+    FirstMoment() {
+        this(0, 0, 0, 0);
+    }
+
+    private FirstMoment(final long n, final double m1, final double dev, final double nDev) {
+        this.n = n;
+        this.m1 = m1;
+        this.dev = dev;
+        this.nDev = nDev;
+    }
+
+    @Override
+    public long getN() {
+        return n;
+    }
+
+    @Override
+    public void merge(UnivaritateStatistic other) {
+        FirstMoment otherFirstMoment = (FirstMoment) other;
+        long otherN = otherFirstMoment.n;
+        double otherDev = otherFirstMoment.dev;
+        double othernDev = otherFirstMoment.nDev;
+        double otherM1 = otherFirstMoment.m1;
+
+        if (otherN == 0) {
+            return; // Nothing to merge
+        }
+
+        if (this.n == 0) {
+            this.n = otherN;
+            this.m1 = otherM1;
+            this.dev = otherDev;
+            this.nDev = othernDev;
+        } else {
+            this.n += otherN;
+
+            double n0 = n;
+            this.dev = otherM1 - m1;
+            this.nDev = otherN * dev / n0;
+            this.m1 += nDev;
+        }
+    }
+
+    @Override
+    public void accept(double value) {
+        n++;
+        double n0 = n;
+        dev = value - m1;
+        nDev = dev / n0;
+        m1 += nDev;
+    }
+
+    @Override
+    public double getAsDouble() {
+        return m1;
+    }
+
+    double getDev() {
+        return dev;
+    }
+
+    double getnDev() {
+        return nDev;
+    }
+}

--- a/sample-stats/src/main/java/org/poc/sample/stats/internal/MomentBasedMean.java
+++ b/sample-stats/src/main/java/org/poc/sample/stats/internal/MomentBasedMean.java
@@ -1,0 +1,33 @@
+package org.poc.sample.stats.internal;
+
+import org.poc.sample.stats.UnivaritateStatistic;
+
+class MomentBasedMean implements UnivaritateStatistic {
+
+    protected final FirstMoment firstMoment;
+
+    MomentBasedMean(final FirstMoment firstMoment) {
+       this.firstMoment = firstMoment;
+    }
+
+    @Override
+    public void accept(double value) {
+        firstMoment.accept(value);
+    }
+
+    @Override
+    public double getAsDouble() {
+        return firstMoment.getAsDouble();
+    }
+
+    @Override
+    public long getN() {
+        return firstMoment.getN();
+    }
+
+    @Override
+    public void merge(UnivaritateStatistic other) {
+        MomentBasedMean otherMomentBasedMean = (MomentBasedMean) other;
+        this.firstMoment.merge(otherMomentBasedMean.firstMoment);
+    }
+}

--- a/sample-stats/src/main/java/org/poc/sample/stats/internal/MomentBasedPopulationVariance.java
+++ b/sample-stats/src/main/java/org/poc/sample/stats/internal/MomentBasedPopulationVariance.java
@@ -1,0 +1,23 @@
+package org.poc.sample.stats.internal;
+
+import org.poc.sample.stats.UnivaritateStatistic;
+
+class MomentBasedPopulationVariance extends MomentBasedVariance {
+
+    MomentBasedPopulationVariance(final SecondMoment secondMoment) {
+        super(secondMoment);
+    }
+
+    @Override
+    protected double getVariance() {
+        long n = secondMoment.getN();
+        double m2 = secondMoment.getAsDouble();
+        return m2 / n;
+    }
+
+    @Override
+    public void merge(UnivaritateStatistic other) {
+        MomentBasedPopulationVariance otherMomentBasedPopulationVariance = (MomentBasedPopulationVariance) other;
+
+    }
+}

--- a/sample-stats/src/main/java/org/poc/sample/stats/internal/MomentBasedSampleVariance.java
+++ b/sample-stats/src/main/java/org/poc/sample/stats/internal/MomentBasedSampleVariance.java
@@ -1,0 +1,22 @@
+package org.poc.sample.stats.internal;
+
+import org.poc.sample.stats.UnivaritateStatistic;
+
+class MomentBasedSampleVariance extends MomentBasedVariance {
+
+    MomentBasedSampleVariance(final SecondMoment secondMoment) {
+        super(secondMoment);
+    }
+
+    @Override
+    public void merge(UnivaritateStatistic other) {
+        // TODO: Implementation
+    }
+
+    @Override
+    protected double getVariance() {
+        long n = super.getN();
+        double m2 = secondMoment.getAsDouble();
+        return m2 / (n - 1d);
+    }
+}

--- a/sample-stats/src/main/java/org/poc/sample/stats/internal/MomentBasedVariance.java
+++ b/sample-stats/src/main/java/org/poc/sample/stats/internal/MomentBasedVariance.java
@@ -1,0 +1,35 @@
+package org.poc.sample.stats.internal;
+
+import org.poc.sample.stats.UnivaritateStatistic;
+
+abstract class MomentBasedVariance implements UnivaritateStatistic {
+    protected final SecondMoment secondMoment;
+
+    MomentBasedVariance(final SecondMoment secondMoment) {
+        this.secondMoment = secondMoment;
+    }
+
+    @Override
+    public long getN() {
+        return secondMoment.getN();
+    }
+
+    @Override
+    public void accept(double value) {
+        secondMoment.accept(value);
+    }
+
+    @Override
+    public double getAsDouble() {
+        long n = secondMoment.getN();
+        if (n == 0) {
+            return Double.NaN;
+        } else if (n == 1) {
+            return 0d;
+        } else {
+            return getVariance();
+        }
+    }
+
+    protected abstract double getVariance();
+}

--- a/sample-stats/src/main/java/org/poc/sample/stats/internal/SecondMoment.java
+++ b/sample-stats/src/main/java/org/poc/sample/stats/internal/SecondMoment.java
@@ -1,0 +1,38 @@
+package org.poc.sample.stats.internal;
+
+import org.poc.sample.stats.UnivaritateStatistic;
+
+class SecondMoment implements UnivaritateStatistic {
+
+    private final FirstMoment firstMoment;
+    private final boolean updateFirstMoment;
+
+    private double m2;
+
+    SecondMoment(final FirstMoment firstMoment, final boolean updateFirstMoment) {
+        this.firstMoment = firstMoment;
+        this.updateFirstMoment = updateFirstMoment;
+    }
+
+    @Override
+    public long getN() {
+        return firstMoment.getN();
+    }
+
+    @Override
+    public void merge(UnivaritateStatistic other) {}
+
+    @Override
+    public void accept(double value) {
+        if (updateFirstMoment) {
+            firstMoment.accept(value);
+        }
+        m2 += ((double) firstMoment.getN() - 1) * firstMoment.getDev() * firstMoment.getnDev();
+    }
+
+    @Override
+    public double getAsDouble() {
+        return m2;
+    }
+
+}

--- a/sample-stats/src/main/java/org/poc/sample/stats/internal/StatisticImplProvider.java
+++ b/sample-stats/src/main/java/org/poc/sample/stats/internal/StatisticImplProvider.java
@@ -1,0 +1,95 @@
+package org.poc.sample.stats.internal;
+
+import org.poc.sample.stats.UnivaritateStatistic;
+import org.poc.sample.stats.config.Statistic;
+import org.poc.sample.stats.config.SummaryStatisticsConfig;
+
+public class StatisticImplProvider {
+
+    private final UnivaritateStatistic sumImpl;
+    private final UnivaritateStatistic meanImpl;
+    private final UnivaritateStatistic varianceImpl;
+
+    private final boolean shouldComputeMean;
+    private final boolean shouldComputeVariance;
+
+    private FirstMoment firstMoment;
+    private SecondMoment secondMoment;
+
+    private StatisticImplProvider(SummaryStatisticsConfig config) {
+
+        boolean shouldComputeSum = config.shouldCompute(Statistic.Sum);
+        shouldComputeMean = config.shouldCompute(Statistic.Mean);
+        shouldComputeVariance = config.shouldCompute(Statistic.Variance);
+
+        boolean useMomentBasedMeanImpl = useMomentBasedMeanImpl(config);
+        boolean useMomentBasedVarianceImpl = useMomentBasedVarianceImpl(config);
+
+        if (shouldComputeSum) {
+            sumImpl = new SumImpl();
+        } else {
+            sumImpl = DefaultUnivariateStatisticImpl.getInstance();
+        }
+
+        boolean firstMomentInitialized = false;
+        if (useMomentBasedMeanImpl) {
+            initializeFirstMoment();
+            firstMomentInitialized = true;
+            meanImpl = new MomentBasedMean(firstMoment);
+        } else {
+            meanImpl = DefaultUnivariateStatisticImpl.getInstance();
+        }
+
+        if (useMomentBasedVarianceImpl) {
+            if (!firstMomentInitialized) {
+                initializeFirstMoment();
+                initializeSecondMoment(true);
+            } else {
+                initializeSecondMoment(false);
+            }
+
+            if (config.getVarianceConfig().isSampleVariance()) {
+                varianceImpl = new MomentBasedSampleVariance(secondMoment);
+            } else if (config.getVarianceConfig().isPopulationVariance()) {
+                varianceImpl = new MomentBasedPopulationVariance(secondMoment);
+            } else {
+                varianceImpl = DefaultUnivariateStatisticImpl.getInstance();
+            }
+        } else {
+            varianceImpl = DefaultUnivariateStatisticImpl.getInstance();
+        }
+    }
+
+    public static StatisticImplProvider initConfig(SummaryStatisticsConfig config) {
+        return new StatisticImplProvider(config);
+    }
+
+    public UnivaritateStatistic getSumImpl() {
+        return sumImpl;
+    }
+
+    public UnivaritateStatistic getMeanImpl() {
+        return meanImpl;
+    }
+
+    public UnivaritateStatistic getVarianceImpl() {
+        return varianceImpl;
+    }
+
+    private boolean useMomentBasedMeanImpl(SummaryStatisticsConfig config) {
+        return shouldComputeMean && config.getMeanConfig().isSum();
+    }
+
+    private boolean useMomentBasedVarianceImpl(SummaryStatisticsConfig config) {
+        return shouldComputeVariance && (config.getVarianceConfig().isSampleVariance()
+                || config.getVarianceConfig().isPopulationVariance());
+    }
+
+    private void initializeFirstMoment() {
+        firstMoment = new FirstMoment();
+    }
+
+    private void initializeSecondMoment(final boolean updateFirstMoment) {
+        secondMoment = new SecondMoment(firstMoment, updateFirstMoment);
+    }
+}

--- a/sample-stats/src/main/java/org/poc/sample/stats/internal/SumImpl.java
+++ b/sample-stats/src/main/java/org/poc/sample/stats/internal/SumImpl.java
@@ -1,0 +1,42 @@
+package org.poc.sample.stats.internal;
+
+import org.poc.sample.stats.UnivaritateStatistic;
+
+class SumImpl implements UnivaritateStatistic {
+
+    private long n;
+
+    private double value;
+
+    SumImpl() {
+        this(0, 0);
+    }
+
+    private SumImpl(final long n, final double value) {
+        this.n = n;
+        this.value = value;
+    }
+
+    @Override
+    public long getN() {
+        return n;
+    }
+
+    @Override
+    public void merge(UnivaritateStatistic other) {
+        SumImpl otherSum = (SumImpl) other;
+        this.n += otherSum.n;
+        this.value += otherSum.value;
+    }
+
+    @Override
+    public void accept(double value) {
+        n++;
+        this.value += value;
+    }
+
+    @Override
+    public double getAsDouble() {
+        return value;
+    }
+}

--- a/sample-stats/src/test/java/DoubleSummaryStatisticsTest.java
+++ b/sample-stats/src/test/java/DoubleSummaryStatisticsTest.java
@@ -1,0 +1,136 @@
+import org.poc.sample.stats.DoubleSummaryStatistics;
+import org.poc.sample.stats.StatisticalSummary;
+import org.poc.sample.stats.config.Statistic;
+import org.poc.sample.stats.config.SummaryStatisticsConfig;
+import org.poc.sample.stats.config.VarianceConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class DoubleSummaryStatisticsTest {
+
+    private final double TOLERANCE = 1e-10;
+
+    @Test
+    public void testSummary() {
+        List<Double> data = Arrays.asList(1.0, 2.0, 3.0, 4.0, -1.0);
+        StatisticalSummary summary = DoubleSummaryStatistics.withDefault()
+                .of(data)
+                .toStatisticalSummary();
+
+        Assertions.assertEquals(9.0d, summary.getSum(), TOLERANCE);
+        Assertions.assertEquals(1.8d, summary.getMean(), TOLERANCE);
+        Assertions.assertEquals(3.7d, summary.getVariance(), TOLERANCE);
+    }
+
+    @Test
+    public void testSummaryOnDoubleStream() {
+        List<Double> data = Arrays.asList(3.0, 2.0, -1.0, 4.0, 1.0);
+        {
+            StatisticalSummary summary = data.parallelStream().collect(DoubleSummaryStatistics.summarize());
+
+            Assertions.assertEquals(9.0d, summary.getSum(), TOLERANCE);
+            Assertions.assertEquals(1.8d, summary.getMean(), TOLERANCE);
+        }
+
+        {
+            StatisticalSummary summary = data.stream().collect(DoubleSummaryStatistics.summarize());
+
+            Assertions.assertEquals(9.0d, summary.getSum(), TOLERANCE);
+            Assertions.assertEquals(1.8d, summary.getMean(), TOLERANCE);
+        }
+
+    }
+
+    @Test
+    public void testSumOnly() {
+        SummaryStatisticsConfig config = SummaryStatisticsConfig.newBuilder()
+                .only(Statistic.Sum)
+                .build();
+        StatisticalSummary summary = DoubleSummaryStatistics.withCustom(config)
+                .addValue(2.0)
+                .addValue(4.0)
+                .addValue(-1.0)
+                .addValue(3.0)
+                .addValue(1.0)
+                .toStatisticalSummary();
+
+        Assertions.assertEquals(9.0d, summary.getSum(), TOLERANCE);
+        // We are only computing Sum
+        Assertions.assertEquals(Double.NaN, summary.getVariance());
+    }
+
+    @Test
+    public void testExcludeSum() {
+        SummaryStatisticsConfig config = SummaryStatisticsConfig.newBuilder()
+                .excluding(Statistic.Sum)
+                .build();
+        StatisticalSummary summary = DoubleSummaryStatistics.withCustom(config)
+                .addValue(3.0)
+                .addValue(-1.0)
+                .addValue(2.0)
+                .addValue(1.0)
+                .addValue(4.0)
+                .toStatisticalSummary();
+
+        Assertions.assertEquals(1.8d, summary.getMean(), TOLERANCE);
+        Assertions.assertEquals(3.7d, summary.getVariance(), TOLERANCE);
+        Assertions.assertEquals(Double.NaN, summary.getSum()); // Sum is excluded
+    }
+
+    @Test
+    public void testMeanOnly() {
+        SummaryStatisticsConfig config = SummaryStatisticsConfig.newBuilder()
+                .only(Statistic.Mean)
+                .build();
+        StatisticalSummary summary = DoubleSummaryStatistics.withCustom(config)
+                .of(Arrays.asList(-1.0, 1.0, 2.0, 3.0, 4.0))
+                .toStatisticalSummary();
+
+        Assertions.assertEquals(Double.NaN, summary.getSum());
+        Assertions.assertEquals(1.8d, summary.getMean(), TOLERANCE);
+    }
+
+    @Test
+    public void testSumAndMeanOnDoubleStream() {
+        List<Double> data = Arrays.asList(4.0, -1.0, 1.0, 3.0, 2.0);
+
+        SummaryStatisticsConfig config = SummaryStatisticsConfig.newBuilder()
+                .only(Statistic.Mean, Statistic.Sum)
+                .build();
+        {
+            StatisticalSummary summary = data.stream().collect(DoubleSummaryStatistics.summarize(config));
+            Assertions.assertEquals(9.0d, summary.getSum(), TOLERANCE);
+            Assertions.assertEquals(1.8d, summary.getMean(), TOLERANCE);
+            Assertions.assertEquals(Double.NaN, summary.getVariance());
+        }
+
+        {
+            StatisticalSummary summary = data.parallelStream().collect(DoubleSummaryStatistics.summarize(config));
+            Assertions.assertEquals(9.0d, summary.getSum(), TOLERANCE);
+            Assertions.assertEquals(1.8d, summary.getMean(), TOLERANCE);
+            Assertions.assertEquals(Double.NaN, summary.getVariance());
+        }
+    }
+
+    @Test
+    public void testPopulationVariance() {
+        SummaryStatisticsConfig config = SummaryStatisticsConfig.newBuilder()
+                .only(Statistic.Variance)
+                .withVarianceConfig(VarianceConfig.Population)
+                .build();
+        StatisticalSummary summary = DoubleSummaryStatistics.withCustom(config)
+                .addValue(1.0)
+                .addValue(-100.333333333333)
+                .addValue(3.14)
+                .addValue(5.6666667)
+                .addValue(-7.2)
+                .toStatisticalSummary();
+
+        Assertions.assertEquals(Double.NaN, summary.getSum());
+        Assertions.assertEquals(Double.NaN, summary.getMean());
+        Assertions.assertEquals(1650.2976, summary.getVariance(), 1e-4);
+    }
+}


### PR DESCRIPTION
- Implemented a class `DoubleSummaryStatistics` to compute all or some of the Statistic values over `double` data value(s).
- All the Statistics to be supported are defined in the `Statistic` enum.
- DoubleSummaryStatistic can be instantiated with a default or a custom `SummaryStatisticsConfig`.
- By default we assume that the user wants to compute ALL statistics defined in the `Statistic` enum.
- In case user wants to compute only a subset of the Statistics, `DoubleSummaryStatistics` can be instantiated with a custom config.
- Every enum value in a config (E.g. `MeanConfig`, `VarianceConfig`) corresponds to a particular implementation to be used while computing the respective Statistic.
- All configs are present in the `org.poc.sample.stats.config` package.
- `StatisticImplProvider` is a factory class that analyzes the `SummaryStatisticsConfig` and supplies the implementations to be used by `DoubleSummaryStatistics` class.
- All Statistic implementations implement the `UnivariateStatistic` interface.
- All Statistic implementations are package-private present in the `org.poc.sample.stats.internal` package.
- Proof of concept only includes 3 Statistics for now: `Sum`, `Mean` and `Variance` to demonstrate the new API and usages. Would include other Statistics once we finalize on the design.
- Sample usages of the API are present in `DoubleSummaryStatisticsTest`